### PR TITLE
Transaction-level search paths

### DIFF
--- a/lib/penthouse/runners/base_runner.rb
+++ b/lib/penthouse/runners/base_runner.rb
@@ -11,44 +11,26 @@ module Penthouse
   module Runners
     class BaseRunner
 
-      PENTHOUSE_RUNNER_CALL_STACK = :current_penthouse_runner_call_stack
-
       # @param tenant_identifier [String, Symbol] The identifier for the tenant
       # @param block [Block] The code to execute within the tenant
       # @return [void]
       # @raise [Penthouse::TenantNotFound] if the tenant cannot be switched to
       def call(tenant_identifier:, &block)
-        previous_tenant_identifier = call_stack.last || 'public'
-        call_stack.push(tenant_identifier)
-
-        result = nil
-
-        begin
-          load_tenant(tenant_identifier: tenant_identifier, previous_tenant_identifier: previous_tenant_identifier).call do |tenant|
-            Penthouse.with_tenant(tenant_identifier: tenant.identifier) do
-              result = block.yield(tenant)
-            end
+        load_tenant(tenant_identifier: tenant_identifier).call do |tenant|
+          Penthouse.with_tenant(tenant_identifier: tenant.identifier) do
+            result = block.yield(tenant)
           end
-        ensure
-          call_stack.pop
         end
-        result
       end
 
       # @abstract returns the tenant object
       # @param tenant_identifier [String, Symbol] The identifier for the tenant
       # @return [Penthouse::Tenants::BaseTenant] An instance of a tenant
       # @raise [Penthouse::TenantNotFound] if the tenant cannot be switched to
-      def load_tenant(tenant_identifier:, previous_tenant_identifier: 'public')
+      def load_tenant(tenant_identifier:)
         raise NotImplementedError
       end
-      
-      private
-      
-      def call_stack
-        Thread.current[PENTHOUSE_RUNNER_CALL_STACK] ||= []
-      end
-      
+
     end
   end
 end

--- a/lib/penthouse/runners/schema_runner.rb
+++ b/lib/penthouse/runners/schema_runner.rb
@@ -11,8 +11,8 @@ module Penthouse
 
       # @param tenant_identifier [String, Symbol] The identifier for the tenant
       # @return [Penthouse::Tenants::BaseTenant] An instance of a tenant
-      def load_tenant(tenant_identifier:, previous_tenant_identifier: 'public')
-        Tenants::SchemaTenant.new(identifier: tenant_identifier, tenant_schema: tenant_identifier, previous_schema: previous_tenant_identifier)
+      def load_tenant(tenant_identifier:)
+        Tenants::SchemaTenant.new(identifier: tenant_identifier, tenant_schema: tenant_identifier)
       end
 
     end

--- a/lib/penthouse/tenants/octopus_shard_tenant.rb
+++ b/lib/penthouse/tenants/octopus_shard_tenant.rb
@@ -11,6 +11,7 @@ require_relative './octopus_schema_tenant'
 module Penthouse
   module Tenants
     class OctopusShardTenant < OctopusSchemaTenant
+      DEFAULT_TENANT_SCHEMA = 'public'.freeze
 
       attr_accessor :shard
       private :shard=
@@ -18,7 +19,7 @@ module Penthouse
       # @param identifier [String, Symbol] An identifier for the tenant
       # @param shard [String, Symbol] the configured Octopus shard to use for this tenant
       # @param tenant_schema [String] your tenant's schema name within the Postgres shard, typically just 'public' as the shard should be dedicated
-      def initialize(identifier:, shard:, tenant_schema: "public", **options)
+      def initialize(identifier:, shard:, tenant_schema: DEFAULT_TENANT_SCHEMA, **options)
         self.shard = shard
         super(identifier: identifier, tenant_schema: tenant_schema, **options)
       end

--- a/lib/penthouse/tenants/schema_tenant.rb
+++ b/lib/penthouse/tenants/schema_tenant.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #
 # The SchemaTenant class simply switches the schema search path to allow for
 # isolated data, but low overheads in terms of costs. Note: this means tenants
@@ -12,9 +13,16 @@ require 'active_record'
 module Penthouse
   module Tenants
     class SchemaTenant < BaseTenant
+      PERSISTENT_SCHEMAS_DEFAULT = 'shared_extensions'.freeze
+
       include Migratable
 
-      attr_accessor :tenant_schema, :persistent_schemas, :default_schema, :previous_schema
+      def self.current_search_path
+        results = ActiveRecord::Base.connection.exec_query('SHOW search_path')
+        results.first.fetch('search_path')
+      end
+
+      attr_accessor :tenant_schema, :persistent_schemas, :default_schema
       private :tenant_schema=, :persistent_schemas=, :default_schema=
 
       # @param identifier [String, Symbol] An identifier for the tenant
@@ -22,12 +30,10 @@ module Penthouse
       # @param persistent_schemas [Array<String>] The schemas you always want in the search path
       # @param default_schema [String] The global schema name, usually 'public'
       # @param previous_schema [String] The previous schema name, usually 'public' unless dealing with nested calls.
-      def initialize(identifier:, tenant_schema:, persistent_schemas: ["shared_extensions"], default_schema: "public", previous_schema: default_schema)
+      def initialize(identifier:, tenant_schema:, persistent_schemas: PERSISTENT_SCHEMAS_DEFAULT)
         super
-        self.tenant_schema = tenant_schema.freeze
-        self.persistent_schemas = Array(persistent_schemas).flatten.freeze
-        self.default_schema = default_schema.freeze
-        self.previous_schema = previous_schema.freeze
+        @tenant_schema = tenant_schema.freeze
+        @persistent_schemas = Array(persistent_schemas).flatten.unshift(tenant_schema).join(', ').freeze
         freeze
       end
 
@@ -37,14 +43,17 @@ module Penthouse
       # @yield [SchemaTenant] The current tenant instance
       # @return [void]
       def call(&block)
-        begin
-          # set the search path to include the tenant
-          ActiveRecord::Base.connection.schema_search_path = persistent_schemas.dup.unshift(tenant_schema).join(", ")
+        previous_schemas = self.class.current_search_path
+        # create a transaction wrapping all calls
+        ActiveRecord::Base.transaction do
+          # set the search path to include this tenant
+          set_search_path(@persistent_schemas)
+          # call the code
           block.yield(self)
-        ensure
-          # reset the search path back to the default
-          ActiveRecord::Base.connection.schema_search_path = persistent_schemas.dup.unshift(previous_schema).join(", ")
         end
+      ensure
+        # reset the search path back for the previous tenant
+        set_search_path(previous_schemas)
       end
 
       # creates the tenant schema
@@ -52,7 +61,7 @@ module Penthouse
       # @param db_schema_file [String] a path to the DB schema file to load, defaults to Penthouse.configuration.db_schema_file
       # @return [void]
       def create(run_migrations: Penthouse.configuration.migrate_tenants?, db_schema_file: Penthouse.configuration.db_schema_file)
-        sql = ActiveRecord::Base.send(:sanitize_sql_array, ["create schema if not exists %s", tenant_schema])
+        sql = ActiveRecord::Base.send(:sanitize_sql_array, ["create schema if not exists %s", @tenant_schema])
         ActiveRecord::Base.connection.exec_query(sql, 'Create Schema')
         if !!run_migrations
           migrate(db_schema_file: db_schema_file)
@@ -63,16 +72,29 @@ module Penthouse
       # @param force [Boolean] whether or not to drop the schema if not empty, defaults to true
       # @return [void]
       def delete(force: true)
-        sql = ActiveRecord::Base.send(:sanitize_sql_array, ["drop schema if exists %s %s", tenant_schema, force ? 'cascade' : 'restrict'])
+        sql = ActiveRecord::Base.send(:sanitize_sql_array, ["drop schema if exists %s %s", @tenant_schema, force ? 'cascade' : 'restrict'])
         ActiveRecord::Base.connection.exec_query(sql, 'Delete Schema')
       end
 
       # returns whether or not this tenant's schema exists
       # @return [Boolean] whether or not the tenant exists
       def exists?(**)
-        sql = ActiveRecord::Base.send(:sanitize_sql_array, ["select 1 from pg_namespace where nspname = '%s'", tenant_schema])
-        result = ActiveRecord::Base.connection.exec_query(sql, "Schema Exists")
+        sql = ActiveRecord::Base.send(:sanitize_sql_array, ["select 1 from pg_namespace where nspname = '%s'", @tenant_schema])
+        result = ActiveRecord::Base.connection.exec_query(sql, 'Schema Exists')
         !result.rows.empty?
+      end
+
+      private
+
+      # sets the Postgres search path to the given schema(s), but only if a transaction is open
+      # @param schemas [Array<String>] The schemas you want to set for the current transaction's search path
+      # @return [void]
+      def set_search_path(*schemas)
+        # we can only set a search path inside transactions, otherwise this is a no-op
+        if ActiveRecord::Base.connection.transaction_open?
+          sql = ActiveRecord::Base.send(:sanitize_sql_array, ["set local search_path to %s", Array(schemas).join(', ')])
+          ActiveRecord::Base.connection.exec_query(sql, 'Switch Schema')
+        end
       end
 
     end

--- a/lib/penthouse/version.rb
+++ b/lib/penthouse/version.rb
@@ -1,3 +1,3 @@
 module Penthouse
-  VERSION = "0.12.0"
+  VERSION = "0.13.0"
 end

--- a/spec/penthouse/configuration_spec.rb
+++ b/spec/penthouse/configuration_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Penthouse::Configuration do
       it 'should raise an ArgumentError' do
         expect do
           described_class.new(migrate_tenants: true, db_schema_file: File.join(File.dirname(__FILE__), "../support/schema.rb"))
-        end.to_not raise_error(ArgumentError)
+        end.to_not raise_error
       end
     end
   end

--- a/spec/penthouse/runners/schema_runner_spec.rb
+++ b/spec/penthouse/runners/schema_runner_spec.rb
@@ -11,26 +11,40 @@ RSpec.describe Penthouse::Runners::SchemaRunner do
     ActiveRecord::Base.connection.execute("create schema if not exists #{schema_name}")
   end
 
+  def current_search_path
+    ActiveRecord::Base.connection.exec_query('SHOW search_path').first.fetch('search_path')
+  end
+
   describe ".call" do
     it "should switch to the relevant Postgres schema" do
       runner.call(tenant_identifier: schema_name) do
-        expect(ActiveRecord::Base.connection.schema_search_path).to include(schema_name)
+        expect(current_search_path).to include(schema_name)
       end
     end
-    
+
     it "should honour nested switches to the relevant Postgres schema" do
       schema_1 = 'schema_1'
       schema_2 = 'schema_2'
+
       runner.call(tenant_identifier: schema_1) do
-        runner.call(tenant_identifier: schema_2) do
-          expect(ActiveRecord::Base.connection.schema_search_path).not_to include(schema_1)
-          expect(ActiveRecord::Base.connection.schema_search_path).to include(schema_2)
+        aggregate_failures 'moving to schema_1' do
+          expect(current_search_path).to include(schema_1)
+          expect(current_search_path).not_to include('public', schema_2)
         end
-        expect(ActiveRecord::Base.connection.schema_search_path).not_to include('public')
-        expect(ActiveRecord::Base.connection.schema_search_path).to include(schema_1)
-        expect(ActiveRecord::Base.connection.schema_search_path).not_to include(schema_2)
+
+        runner.call(tenant_identifier: schema_2) do
+          aggregate_failures 'moving to schema_2' do
+            expect(current_search_path).to include(schema_2)
+            expect(current_search_path).not_to include('public', schema_1)
+          end
+        end
+
+        aggregate_failures 'returning to schema_1' do
+          expect(current_search_path).to include(schema_1)
+          expect(current_search_path).not_to include('public', schema_2)
+        end
       end
     end
-    
+
   end
 end

--- a/spec/penthouse/tenants/octopus_schema_tenant_spec.rb
+++ b/spec/penthouse/tenants/octopus_schema_tenant_spec.rb
@@ -6,15 +6,13 @@ require_relative '../../support/models'
 RSpec.describe Penthouse::Tenants::OctopusSchemaTenant do
   let(:schema_name) { "octopus_schema_tenant_test" }
   let(:persistent_schemas) { ["shared_extensions"] }
-  let(:default_schema) { "public" }
   let(:db_schema_file) { File.join(File.dirname(__FILE__), '../../support/schema.rb') }
 
   subject(:octopus_schema_tenant) {
     described_class.new(
       identifier: schema_name,
       tenant_schema: schema_name,
-      persistent_schemas: persistent_schemas,
-      default_schema: default_schema
+      persistent_schemas: persistent_schemas
     )
   }
 

--- a/spec/penthouse/tenants/schema_tenant_spec.rb
+++ b/spec/penthouse/tenants/schema_tenant_spec.rb
@@ -5,13 +5,12 @@ require 'penthouse/tenants/schema_tenant'
 RSpec.describe Penthouse::Tenants::SchemaTenant do
   let(:schema_name) { "schema_tenant_test" }
   let(:persistent_schemas) { ["shared_extensions"] }
-  let(:default_schema) { "public" }
 
   subject(:schema_tenant) do
-    described_class.new(identifier: schema_name,
+    described_class.new(
+      identifier: schema_name,
       tenant_schema: schema_name,
-      persistent_schemas: persistent_schemas,
-      default_schema: default_schema
+      persistent_schemas: persistent_schemas
     )
   end
 
@@ -20,10 +19,17 @@ RSpec.describe Penthouse::Tenants::SchemaTenant do
     after(:each) { schema_tenant.delete }
 
     it "should switch to the relevant Postgres schema" do
-      schema_tenant.call do
-        expect(ActiveRecord::Base.connection.schema_search_path).to eq([schema_name, *persistent_schemas].join(", "))
+      search_path = -> {
+        ActiveRecord::Base.connection.exec_query('SHOW search_path').first.fetch('search_path')
+      }
+
+      original_search_path = search_path.call
+      aggregate_failures do
+        schema_tenant.call do
+          expect(search_path.call).to eq([schema_name, *persistent_schemas].join(', '))
+        end
+        expect(search_path.call).to eq(original_search_path)
       end
-      expect(ActiveRecord::Base.connection.schema_search_path).to eq([default_schema, *persistent_schemas].join(", "))
     end
   end
 end


### PR DESCRIPTION
Race conditions occur with using `SET` within PgBouncer as this sets configuration options on a session-basis, whereas to get the performance benefits of PgBouncer, we need to use transaction-based pooling.

This PR updates Penthouse to use transactions and `SET LOCAL` in order to avoid this problem.