### PR TITLE
Remove use of search_path and prefix tables instead

### DIFF
--- a/lib/penthouse.rb
+++ b/lib/penthouse.rb
@@ -1,12 +1,15 @@
 require "penthouse/migrator"
 require "penthouse/version"
 require "penthouse/configuration"
+require "penthouse/active_record"
 require "penthouse/routers/base_router"
 require "penthouse/runners/base_runner"
 
 module Penthouse
   class TenantNotFound < RuntimeError; end
+
   CURRENT_TENANT_KEY = 'penthouse_tenant'.freeze
+  SCHEMA_CHAIN_KEY = 'penthouse_schema_chain'.freeze
 
   class << self
     # Retrieves the currently active tenant identifier
@@ -20,6 +23,18 @@ module Penthouse
     # @return [void]
     def tenant=(tenant_identifier)
       Thread.current[CURRENT_TENANT_KEY] = tenant_identifier
+    end
+
+    # Retrieves the schemas with nesting
+    # @return [Array<String, Symbol>] the list of schemas, the last being the currently active
+    def schema_chain
+      Thread.current[SCHEMA_CHAIN_KEY] ||= []
+    end
+
+    # Retrieves the currently active tenant schema
+    # @return [String, Symbol] the current tenant name
+    def current_schema
+      schema_chain.last
     end
 
     # Similar to Penthouse.tenant=, except this will switch back after the given

--- a/lib/penthouse/active_record.rb
+++ b/lib/penthouse/active_record.rb
@@ -1,0 +1,17 @@
+class ActiveRecord::Base
+  DEFAULT_SCHEMA_NAME = 'public'.freeze
+
+  # override table name so it's calculated EVERY time
+  def self.table_name
+    reset_table_name
+  end
+
+  # set a table name prefix which is dynamic based on the current schema
+  def self.table_name_prefix
+    if Penthouse.current_schema.nil?
+      DEFAULT_SCHEMA_NAME
+    else
+      "#{Penthouse.current_schema}."
+    end
+  end
+end

--- a/lib/penthouse/active_record.rb
+++ b/lib/penthouse/active_record.rb
@@ -1,3 +1,6 @@
+# Note: we cannot monkey-patch via an extend here as we need to alter the
+# underlying method to ensure all subclasses inherit the change
+
 class ActiveRecord::Base
   DEFAULT_SCHEMA_NAME = 'public'.freeze
 

--- a/lib/penthouse/runners/base_runner.rb
+++ b/lib/penthouse/runners/base_runner.rb
@@ -11,44 +11,26 @@ module Penthouse
   module Runners
     class BaseRunner
 
-      PENTHOUSE_RUNNER_CALL_STACK = :current_penthouse_runner_call_stack
-
       # @param tenant_identifier [String, Symbol] The identifier for the tenant
       # @param block [Block] The code to execute within the tenant
       # @return [void]
       # @raise [Penthouse::TenantNotFound] if the tenant cannot be switched to
       def call(tenant_identifier:, &block)
-        previous_tenant_identifier = call_stack.last || 'public'
-        call_stack.push(tenant_identifier)
-
-        result = nil
-
-        begin
-          load_tenant(tenant_identifier: tenant_identifier, previous_tenant_identifier: previous_tenant_identifier).call do |tenant|
-            Penthouse.with_tenant(tenant_identifier: tenant.identifier) do
-              result = block.yield(tenant)
-            end
+        load_tenant(tenant_identifier: tenant_identifier).call do |tenant|
+          Penthouse.with_tenant(tenant_identifier: tenant.identifier) do
+            result = block.yield(tenant)
           end
-        ensure
-          call_stack.pop
         end
-        result
       end
 
       # @abstract returns the tenant object
       # @param tenant_identifier [String, Symbol] The identifier for the tenant
       # @return [Penthouse::Tenants::BaseTenant] An instance of a tenant
       # @raise [Penthouse::TenantNotFound] if the tenant cannot be switched to
-      def load_tenant(tenant_identifier:, previous_tenant_identifier: 'public')
+      def load_tenant(tenant_identifier:)
         raise NotImplementedError
       end
-      
-      private
-      
-      def call_stack
-        Thread.current[PENTHOUSE_RUNNER_CALL_STACK] ||= []
-      end
-      
+
     end
   end
 end

--- a/lib/penthouse/runners/schema_runner.rb
+++ b/lib/penthouse/runners/schema_runner.rb
@@ -11,8 +11,11 @@ module Penthouse
 
       # @param tenant_identifier [String, Symbol] The identifier for the tenant
       # @return [Penthouse::Tenants::BaseTenant] An instance of a tenant
-      def load_tenant(tenant_identifier:, previous_tenant_identifier: 'public')
-        Tenants::SchemaTenant.new(identifier: tenant_identifier, tenant_schema: tenant_identifier, previous_schema: previous_tenant_identifier)
+      def load_tenant(tenant_identifier:)
+        Tenants::SchemaTenant.new(
+          identifier: tenant_identifier,
+          tenant_schema: tenant_identifier
+        )
       end
 
     end

--- a/lib/penthouse/tenants/schema_tenant.rb
+++ b/lib/penthouse/tenants/schema_tenant.rb
@@ -14,20 +14,11 @@ module Penthouse
     class SchemaTenant < BaseTenant
       include Migratable
 
-      attr_accessor :tenant_schema, :persistent_schemas, :default_schema, :previous_schema
-      private :tenant_schema=, :persistent_schemas=, :default_schema=
-
       # @param identifier [String, Symbol] An identifier for the tenant
       # @param tenant_schema [String] your tenant's schema name in Postgres
-      # @param persistent_schemas [Array<String>] The schemas you always want in the search path
-      # @param default_schema [String] The global schema name, usually 'public'
-      # @param previous_schema [String] The previous schema name, usually 'public' unless dealing with nested calls.
-      def initialize(identifier:, tenant_schema:, persistent_schemas: ["shared_extensions"], default_schema: "public", previous_schema: default_schema)
+      def initialize(identifier:, tenant_schema:)
         super
-        self.tenant_schema = tenant_schema.freeze
-        self.persistent_schemas = Array(persistent_schemas).flatten.freeze
-        self.default_schema = default_schema.freeze
-        self.previous_schema = previous_schema.freeze
+        @tenant_schema = tenant_schema.freeze
         freeze
       end
 
@@ -37,14 +28,13 @@ module Penthouse
       # @yield [SchemaTenant] The current tenant instance
       # @return [void]
       def call(&block)
-        begin
-          # set the search path to include the tenant
-          ActiveRecord::Base.connection.schema_search_path = persistent_schemas.dup.unshift(tenant_schema).join(", ")
-          block.yield(self)
-        ensure
-          # reset the search path back to the default
-          ActiveRecord::Base.connection.schema_search_path = persistent_schemas.dup.unshift(previous_schema).join(", ")
-        end
+        # add the current schema to the chain
+        Penthouse.schema_chain.push @tenant_schema
+        # execute the code
+        block.yield(self)
+      ensure
+        # remove the current schema
+        Penthouse.schema_chain.pop
       end
 
       # creates the tenant schema
@@ -52,7 +42,7 @@ module Penthouse
       # @param db_schema_file [String] a path to the DB schema file to load, defaults to Penthouse.configuration.db_schema_file
       # @return [void]
       def create(run_migrations: Penthouse.configuration.migrate_tenants?, db_schema_file: Penthouse.configuration.db_schema_file)
-        sql = ActiveRecord::Base.send(:sanitize_sql_array, ["create schema if not exists %s", tenant_schema])
+        sql = ActiveRecord::Base.send(:sanitize_sql_array, ["create schema if not exists %s", @tenant_schema])
         ActiveRecord::Base.connection.exec_query(sql, 'Create Schema')
         if !!run_migrations
           migrate(db_schema_file: db_schema_file)
@@ -63,14 +53,14 @@ module Penthouse
       # @param force [Boolean] whether or not to drop the schema if not empty, defaults to true
       # @return [void]
       def delete(force: true)
-        sql = ActiveRecord::Base.send(:sanitize_sql_array, ["drop schema if exists %s %s", tenant_schema, force ? 'cascade' : 'restrict'])
+        sql = ActiveRecord::Base.send(:sanitize_sql_array, ["drop schema if exists %s %s", @tenant_schema, force ? 'cascade' : 'restrict'])
         ActiveRecord::Base.connection.exec_query(sql, 'Delete Schema')
       end
 
       # returns whether or not this tenant's schema exists
       # @return [Boolean] whether or not the tenant exists
       def exists?(**)
-        sql = ActiveRecord::Base.send(:sanitize_sql_array, ["select 1 from pg_namespace where nspname = '%s'", tenant_schema])
+        sql = ActiveRecord::Base.send(:sanitize_sql_array, ["select 1 from pg_namespace where nspname = '%s'", @tenant_schema])
         result = ActiveRecord::Base.connection.exec_query(sql, "Schema Exists")
         !result.rows.empty?
       end

--- a/spec/penthouse/configuration_spec.rb
+++ b/spec/penthouse/configuration_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Penthouse::Configuration do
       it 'should raise an ArgumentError' do
         expect do
           described_class.new(migrate_tenants: true, db_schema_file: File.join(File.dirname(__FILE__), "../support/schema.rb"))
-        end.to_not raise_error(ArgumentError)
+        end.to_not raise_error
       end
     end
   end

--- a/spec/penthouse/tenants/octopus_schema_tenant_spec.rb
+++ b/spec/penthouse/tenants/octopus_schema_tenant_spec.rb
@@ -5,16 +5,12 @@ require_relative '../../support/models'
 
 RSpec.describe Penthouse::Tenants::OctopusSchemaTenant do
   let(:schema_name) { "octopus_schema_tenant_test" }
-  let(:persistent_schemas) { ["shared_extensions"] }
-  let(:default_schema) { "public" }
   let(:db_schema_file) { File.join(File.dirname(__FILE__), '../../support/schema.rb') }
 
   subject(:octopus_schema_tenant) {
     described_class.new(
       identifier: schema_name,
-      tenant_schema: schema_name,
-      persistent_schemas: persistent_schemas,
-      default_schema: default_schema
+      tenant_schema: schema_name
     )
   }
 
@@ -35,6 +31,7 @@ RSpec.describe Penthouse::Tenants::OctopusSchemaTenant do
       it "should create the relevant Postgres schema and tables" do
         octopus_schema_tenant.create(run_migrations: true, db_schema_file: db_schema_file)
         octopus_schema_tenant.call do |tenant|
+          expect(Post.table_name).to eq("#{schema_name}.posts")
           expect(Post.create(title: "test", description: "test")).to be_persisted
           expect(Post.count).to eq(1)
         end

--- a/spec/penthouse/tenants/schema_tenant_spec.rb
+++ b/spec/penthouse/tenants/schema_tenant_spec.rb
@@ -4,14 +4,11 @@ require 'penthouse/tenants/schema_tenant'
 
 RSpec.describe Penthouse::Tenants::SchemaTenant do
   let(:schema_name) { "schema_tenant_test" }
-  let(:persistent_schemas) { ["shared_extensions"] }
-  let(:default_schema) { "public" }
 
   subject(:schema_tenant) do
-    described_class.new(identifier: schema_name,
-      tenant_schema: schema_name,
-      persistent_schemas: persistent_schemas,
-      default_schema: default_schema
+    described_class.new(
+      identifier: schema_name,
+      tenant_schema: schema_name
     )
   end
 
@@ -20,10 +17,11 @@ RSpec.describe Penthouse::Tenants::SchemaTenant do
     after(:each) { schema_tenant.delete }
 
     it "should switch to the relevant Postgres schema" do
+      expect(Penthouse.current_schema).to be_nil
       schema_tenant.call do
-        expect(ActiveRecord::Base.connection.schema_search_path).to eq([schema_name, *persistent_schemas].join(", "))
+        expect(Penthouse.current_schema).to eq(schema_name)
       end
-      expect(ActiveRecord::Base.connection.schema_search_path).to eq([default_schema, *persistent_schemas].join(", "))
+      expect(Penthouse.current_schema).to be_nil
     end
   end
 end


### PR DESCRIPTION
Alternative to #5.

This doesn't rely on transactions, instead it explicitly prefixes tables with their schema name.