### PR TITLE
Active record shards support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /doc/
 /pkg/
 /spec/reports/
+/spec/support/active_record_shards.yml
 /spec/support/database.yml
 /spec/support/octopus.yml
 /tmp/

--- a/lib/penthouse.rb
+++ b/lib/penthouse.rb
@@ -3,6 +3,8 @@ require "penthouse/version"
 require "penthouse/configuration"
 require "penthouse/routers/base_router"
 require "penthouse/runners/base_runner"
+require "penthouse/log_subscriber"
+require "penthouse/abstract_adapter"
 
 module Penthouse
   class TenantNotFound < RuntimeError; end

--- a/lib/penthouse/abstract_adapter.rb
+++ b/lib/penthouse/abstract_adapter.rb
@@ -12,11 +12,8 @@ module Penthouse
         end
 
         def instrument(name, payload = {}, &block)
-          # p "lol"
-          # raise "WAT"
-          # binding.pry
-          payload[:octopus_shard] ||= @adapter.octopus_shard
-          payload[:penthouse_prefix] = "[Tenant #{::Penthouse.tenant.inspect} on shard #{::ActiveRecord::Base.current_shard_id.inspect}]"
+          payload[:penthouse_db] ||= @adapter.active_record_database
+          payload[:penthouse_tenant] ||= ::Penthouse.tenant
           @instrumenter.instrument(name, payload, &block)
         end
 
@@ -25,8 +22,8 @@ module Penthouse
         end
       end
 
-      def octopus_shard
-        @config[:octopus_shard]
+      def active_record_database
+        @config[:database]
       end
 
       def initialize(*args)

--- a/lib/penthouse/abstract_adapter.rb
+++ b/lib/penthouse/abstract_adapter.rb
@@ -1,0 +1,40 @@
+require "active_record"
+
+module Penthouse
+  module AbstractAdapter
+    module ActiveRecordShard
+      parent = ActiveSupport::ProxyObject
+
+      class InstrumenterDecorator < parent
+        def initialize(adapter, instrumenter)
+          @adapter = adapter
+          @instrumenter = instrumenter
+        end
+
+        def instrument(name, payload = {}, &block)
+          # p "lol"
+          # raise "WAT"
+          # binding.pry
+          payload[:octopus_shard] ||= @adapter.octopus_shard
+          payload[:penthouse_prefix] = "[Tenant #{::Penthouse.tenant.inspect} on shard #{::ActiveRecord::Base.current_shard_id.inspect}]"
+          @instrumenter.instrument(name, payload, &block)
+        end
+
+        def method_missing(meth, *args, &block)
+          @instrumenter.send(meth, *args, &block)
+        end
+      end
+
+      def octopus_shard
+        @config[:octopus_shard]
+      end
+
+      def initialize(*args)
+        super
+        @instrumenter = InstrumenterDecorator.new(self, @instrumenter)
+      end
+    end
+  end
+end
+
+ActiveRecord::ConnectionAdapters::AbstractAdapter.send(:prepend, Penthouse::AbstractAdapter::ActiveRecordShard)

--- a/lib/penthouse/log_subscriber.rb
+++ b/lib/penthouse/log_subscriber.rb
@@ -1,0 +1,23 @@
+require "active_record"
+
+module Penthouse
+  module LogSubscriber
+    def self.included(base)
+      base.send(:attr_accessor, :penthouse_prefix)
+      base.alias_method_chain :sql, :penthouse_shard
+      base.alias_method_chain :debug, :penthouse_shard
+    end
+
+    def sql_with_penthouse_shard(event)
+      self.penthouse_prefix = event.payload[:penthouse_prefix]
+      sql_without_penthouse_shard(event)
+    end
+
+    def debug_with_penthouse_shard(msg)
+      conn = penthouse_prefix ? color(penthouse_prefix, ActiveSupport::LogSubscriber::GREEN, true) : ''
+      debug_without_penthouse_shard(conn + msg)
+    end
+  end
+end
+
+ActiveRecord::LogSubscriber.send(:include, Penthouse::LogSubscriber)

--- a/lib/penthouse/log_subscriber.rb
+++ b/lib/penthouse/log_subscriber.rb
@@ -20,7 +20,7 @@ module Penthouse
       prefix = []
       prefix << "DB #{penthouse_db}" if penthouse_db
       prefix << "tenant #{penthouse_tenant}" if penthouse_tenant
-      conn = prefix ? color("[#{prefix.join(', ')}]", ActiveSupport::LogSubscriber::GREEN, true) : ''
+      conn = prefix.present? ? color("[#{prefix.join(', ')}]", ActiveSupport::LogSubscriber::GREEN, true) : ''
       debug_without_penthouse_shard(conn + msg)
     end
   end

--- a/lib/penthouse/migrator.rb
+++ b/lib/penthouse/migrator.rb
@@ -14,6 +14,10 @@ module Penthouse
     def current_tenant
       "Tenant: #{Penthouse.tenant || '*** global ***'}"
     end
+
+    def migrate_with_forced_shard(direction)
+      migrate_without_forced_shard(direction)
+    end
   end
 end
 

--- a/lib/penthouse/migrator.rb
+++ b/lib/penthouse/migrator.rb
@@ -120,5 +120,5 @@ module Penthouse
   end
 end
 
-ActiveRecord::Migration.send(:include, Penthouse::Migration)
+ActiveRecord::Migration.send(:prepend, Penthouse::Migration)
 ActiveRecord::Migrator.send(:include, Penthouse::Migrator)

--- a/lib/penthouse/tenants/active_record_shards_tenant.rb
+++ b/lib/penthouse/tenants/active_record_shards_tenant.rb
@@ -1,0 +1,60 @@
+#
+# The ActiveRecordShardsTenant class relies upon ActiveRecordShards [1], it switches to a
+# different shard per tenant, allowing for each tenant to have their own
+# database, 100% isolated from other tenants in terms of data and performance.
+#
+# [1]: (https://github.com/zendesk/active_record_shards)
+#
+
+require_relative './schema_tenant'
+
+module Penthouse
+  module Tenants
+    class ActiveRecordShardsTenant < SchemaTenant
+
+      attr_accessor :shard
+      private :shard=
+
+      # @param identifier [String, Symbol] An identifier for the tenant
+      # @param shard [String, Symbol] the configured ActiveRecordShards shard to use for this tenant
+      # @param tenant_schema [String] your tenant's schema name within the Postgres shard, typically just 'public' as the shard should be dedicated
+      def initialize(identifier:, shard: nil, tenant_schema: "public", **options)
+        self.shard = shard
+        super(identifier: identifier, tenant_schema: tenant_schema, **options)
+      end
+
+      # ensures we're on the correct ActiveRecordShards shard, then just updates the schema
+      # name with the tenant name
+      # @param shard [String, Symbol] The shard to execute within, usually master
+      # @param block [Block] The code to execute within the schema
+      # @yield [SchemaTenant] The current tenant instance
+      # @return [void]
+      def call(&block)
+        ActiveRecord::Base.on_shard(shard) do
+          super(&block)
+        end
+      end
+
+      # creates the tenant schema within the master shard
+      # @see Penthouse::Tenants::SchemaTenant#create
+      # @return [void]
+      def create(*args)
+        call { super }
+      end
+
+      # drops the tenant schema within the master shard
+      # @see Penthouse::Tenants::SchemaTenant#delete
+      # @return [void]
+      def delete(**)
+        call { super }
+      end
+
+      # returns whether or not the schema exists
+      # @see Penthouse::Tenants::SchemaTenant#exists?
+      # @return [Boolean] whether or not the schema exists in the master shard
+      def exists?(**)
+        call { super }
+      end
+    end
+  end
+end

--- a/penthouse.gemspec
+++ b/penthouse.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack', '~> 1.6.4'
   # db
   spec.add_development_dependency 'ar-octopus', '~> 0.8.6'
+  spec.add_development_dependency 'active_record_shards', '~> 3.7', '>= 3.7.2'
   spec.add_development_dependency 'activesupport', '~> 4.2.6'
   spec.add_development_dependency 'activerecord', '~> 4.2.6'
   spec.add_development_dependency 'pg'

--- a/spec/active_record_shards_helper.rb
+++ b/spec/active_record_shards_helper.rb
@@ -1,7 +1,16 @@
-require_relative './activerecord_helper'
-require 'active_record_shards'
 require 'yaml'
 
-ActiveRecord::Base.configurations = YAML.load_file(File.join(File.dirname(__FILE__), "support/active_record_shards.yml"))
-ENV['RAILS_ENV'] = 'test'
-ActiveRecord::Base.logger = Logger.new(STDOUT)
+RSpec.configure do |config|
+  config.around(:each) do |example|
+    if example.metadata[:sharder] == :active_record_shards
+      require 'active_record_shards'
+      ActiveRecord::Base.clear_all_connections! rescue nil
+      ActiveRecord::Base.configurations = YAML.load_file(File.join(File.dirname(__FILE__), "support/active_record_shards.yml"))
+      ENV['RAILS_ENV'] = 'test'
+      ActiveRecord::Base.logger = Logger.new(STDOUT)
+    end
+
+    example.run
+  end
+end
+

--- a/spec/active_record_shards_helper.rb
+++ b/spec/active_record_shards_helper.rb
@@ -1,0 +1,7 @@
+require_relative './activerecord_helper'
+require 'active_record_shards'
+require 'yaml'
+
+ActiveRecord::Base.configurations = YAML.load_file(File.join(File.dirname(__FILE__), "support/active_record_shards.yml"))
+ENV['RAILS_ENV'] = 'test'
+ActiveRecord::Base.logger = Logger.new(STDOUT)

--- a/spec/activerecord_helper.rb
+++ b/spec/activerecord_helper.rb
@@ -2,4 +2,13 @@ require 'active_record'
 require 'yaml'
 require 'pg'
 
-ActiveRecord::Base.establish_connection YAML.load_file(File.join(File.dirname(__FILE__), "support/database.yml")).fetch("test")
+RSpec.configure do |config|
+  config.around(:each) do |example|
+    if example.metadata[:sharder].blank?
+      ActiveRecord::Base.clear_all_connections! rescue nil
+      ActiveRecord::Base.establish_connection YAML.load_file(File.join(File.dirname(__FILE__), "support/database.yml")).fetch("test")
+    end
+
+    example.run
+  end
+end

--- a/spec/octopus_helper.rb
+++ b/spec/octopus_helper.rb
@@ -1,7 +1,18 @@
 require_relative './activerecord_helper'
-require 'octopus'
 
-Octopus.setup do |config|
-  config.environments = [:test]
-  config.shards = YAML.load_file(File.join(File.dirname(__FILE__), "support/octopus.yml")).fetch("octopus").fetch("shards")
+RSpec.configure do |config|
+  config.around(:each) do |example|
+    if example.metadata[:sharder] == :octopus
+      require 'octopus'
+      ActiveRecord::Base.clear_all_connections! rescue nil
+      ActiveRecord::Base.establish_connection YAML.load_file(File.join(File.dirname(__FILE__), "support/database.yml")).fetch("test")
+      Octopus.setup do |config|
+        config.environments = [:test]
+        config.shards = YAML.load_file(File.join(File.dirname(__FILE__), "support/octopus.yml")).fetch("octopus").fetch("shards")
+      end
+    end
+
+    example.run
+  end
 end
+

--- a/spec/penthouse/tenants/active_record_shards_tenant_spec.rb
+++ b/spec/penthouse/tenants/active_record_shards_tenant_spec.rb
@@ -3,7 +3,7 @@ require 'active_record_shards_helper'
 require 'penthouse/tenants/active_record_shards_tenant'
 require_relative '../../support/models'
 
-RSpec.describe Penthouse::Tenants::ActiveRecordShardsTenant do
+RSpec.describe Penthouse::Tenants::ActiveRecordShardsTenant, sharder: :active_record_shards do
   SHARDS = [nil, "one"]
   SCHEMAS = ["public", "ar_schema_tenant_test"]
 

--- a/spec/penthouse/tenants/active_record_shards_tenant_spec.rb
+++ b/spec/penthouse/tenants/active_record_shards_tenant_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+require 'active_record_shards_helper'
+require 'penthouse/tenants/active_record_shards_tenant'
+require_relative '../../support/models'
+
+RSpec.describe Penthouse::Tenants::ActiveRecordShardsTenant do
+  SHARDS = [nil, "one"]
+  SCHEMAS = ["public", "ar_schema_tenant_test"]
+
+  SHARDS.product(SCHEMAS).each do |default_shard_name, schema_name|
+    context "schema '#{schema_name}' on shard '#{default_shard_name}'" do
+
+      subject(:active_record_shards_tenant) {
+        described_class.new(
+          identifier: schema_name,
+          shard: shard_name,
+          tenant_schema: schema_name,
+          persistent_schemas: persistent_schemas,
+          default_schema: default_schema
+        )
+      }
+
+      let(:shard_name) { default_shard_name }
+      let(:persistent_schemas) { ["shared_extensions"] }
+      let(:default_schema) { "public" }
+      let(:db_schema_file) { File.join(File.dirname(__FILE__), '../../support/schema.rb') }
+
+      describe "#call" do
+        context "with a valid shard" do
+          it "should switch to the relevant shard" do
+            subject.call do
+              expect(ActiveRecord::Base.connection.schema_search_path).to include(schema_name)
+            end
+          end
+        end
+
+        context "with an invalid shard" do
+          let(:shard_name) { "invalid_shard" }
+
+          it "should raise an exception" do
+            expect do
+              subject.call { true }
+            end.to raise_error(StandardError)
+          end
+        end
+      end
+
+      describe "#create" do
+        after(:each) do
+          active_record_shards_tenant.delete
+          expect(subject.exists?).to be false
+        end
+
+        context "without running migrations" do
+          it "should create the relevant Postgres schema" do
+            active_record_shards_tenant.create(run_migrations: false, db_schema_file: nil)
+            expect(subject.exists?).to be true
+          end
+        end
+
+        context "when running migrations" do
+          it "should create the relevant Postgres schema and tables" do
+            active_record_shards_tenant.create(run_migrations: true, db_schema_file: db_schema_file)
+            active_record_shards_tenant.call do |tenant|
+              expect(tenant.identifier).to eq(schema_name)
+              expect(Post.create(title: "test", description: "test")).to be_persisted
+              expect(Post.count).to eq(1)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/penthouse/tenants/octopus_schema_tenant_spec.rb
+++ b/spec/penthouse/tenants/octopus_schema_tenant_spec.rb
@@ -3,7 +3,7 @@ require 'octopus_helper'
 require 'penthouse/tenants/octopus_schema_tenant'
 require_relative '../../support/models'
 
-RSpec.describe Penthouse::Tenants::OctopusSchemaTenant do
+RSpec.describe Penthouse::Tenants::OctopusSchemaTenant, sharder: :octopus do
   let(:schema_name) { "octopus_schema_tenant_test" }
   let(:persistent_schemas) { ["shared_extensions"] }
   let(:default_schema) { "public" }

--- a/spec/penthouse/tenants/octopus_shard_tenant_spec.rb
+++ b/spec/penthouse/tenants/octopus_shard_tenant_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'octopus_helper'
 require 'penthouse/tenants/octopus_shard_tenant'
 
-RSpec.describe Penthouse::Tenants::OctopusShardTenant do
+RSpec.describe Penthouse::Tenants::OctopusShardTenant, sharder: :octopus do
   subject { described_class.new(identifier: shard_name, shard: shard_name) }
 
   describe "#call" do

--- a/spec/support/active_record_shards.yml.example
+++ b/spec/support/active_record_shards.yml.example
@@ -1,0 +1,21 @@
+default: &default
+  host: localhost
+  adapter: postgresql
+  encoding: unicode
+  pool: 10
+  port: 5432
+  username:
+  password:
+
+test:
+  <<: *default
+  database: penthouse_test
+
+  shards:
+    one:
+      <<: *default
+      database: penthouse_shard_one
+
+    two:
+      <<: *default
+      database: penthouse_shard_two


### PR DESCRIPTION
Add support of active record shards.
Specs were updated so they can run simultaneously (at least locally), wonder if there is a better way to test octopus & active_record_shards independently.
Also added logging prefix similar to the one provided by octopus.