### PR TITLE
Clear query cache before and after yielding to block

### DIFF
--- a/lib/penthouse/tenants/schema_tenant.rb
+++ b/lib/penthouse/tenants/schema_tenant.rb
@@ -40,10 +40,12 @@ module Penthouse
         begin
           # set the search path to include the tenant
           ActiveRecord::Base.connection.schema_search_path = persistent_schemas.dup.unshift(tenant_schema).join(", ")
+          ActiveRecord::Base.connection.clear_query_cache
           block.yield(self)
         ensure
           # reset the search path back to the default
           ActiveRecord::Base.connection.schema_search_path = persistent_schemas.dup.unshift(previous_schema).join(", ")
+          ActiveRecord::Base.connection.clear_query_cache
         end
       end
 

--- a/lib/penthouse/version.rb
+++ b/lib/penthouse/version.rb
@@ -1,3 +1,3 @@
 module Penthouse
-  VERSION = "0.12.0"
+  VERSION = "0.12.1"
 end

--- a/spec/penthouse/tenants/schema_tenant_spec.rb
+++ b/spec/penthouse/tenants/schema_tenant_spec.rb
@@ -25,5 +25,16 @@ RSpec.describe Penthouse::Tenants::SchemaTenant do
       end
       expect(ActiveRecord::Base.connection.schema_search_path).to eq([default_schema, *persistent_schemas].join(", "))
     end
+
+    it "should clear query cache before and after yielding to block" do
+      relation = double("Relation")
+      expect(ActiveRecord::Base.connection).to receive(:clear_query_cache).ordered
+      expect(relation).to receive(:some_method).ordered
+      expect(ActiveRecord::Base.connection).to receive(:clear_query_cache).ordered
+
+      schema_tenant.call do
+        relation.some_method
+      end
+    end
   end
 end


### PR DESCRIPTION
Make sure query cache is cleared before and after yielding so no data from one tenant is loaded into another from the cache.