### PR TITLE
Improve structure.sql support

### DIFF
--- a/lib/penthouse/tenants/migratable.rb
+++ b/lib/penthouse/tenants/migratable.rb
@@ -68,8 +68,10 @@ module Penthouse
 
       def sanitize_sql(sql)
         sql
+          .gsub(/SELECT pg_catalog.set_config\(\'search_path.*;/, '')
           .gsub(/SET search_path.*;/, '')
           .gsub(/CREATE SCHEMA/, 'CREATE SCHEMA IF NOT EXISTS')
+          .gsub(/public\./, '')
       end
     end
   end

--- a/lib/penthouse/version.rb
+++ b/lib/penthouse/version.rb
@@ -1,3 +1,3 @@
 module Penthouse
-  VERSION = "0.13"
+  VERSION = "0.13.1"
 end

--- a/spec/support/structure.sql
+++ b/spec/support/structure.sql
@@ -1,6 +1,7 @@
+SELECT pg_catalog.set_config('search_path', '', false);
 SET search_path = this_should_get_replaced;
 
-CREATE TABLE posts (
+CREATE TABLE public.posts (
     id integer NOT NULL,
     title character varying NOT NULL,
     description character varying NOT NULL,


### PR DESCRIPTION
Blacklists more schema-changing statements which can be generated in `structure.sql`.