### PR TITLE
Update OctopusSchemaTenant to not make unnecessary schema changes

### DIFF
--- a/lib/penthouse/tenants/octopus_schema_tenant.rb
+++ b/lib/penthouse/tenants/octopus_schema_tenant.rb
@@ -49,7 +49,7 @@ module Penthouse
 
       def switch_shard(shard: Octopus.master_shard, &block)
         Octopus.using(shard) do
-          super(&block)
+          block.call
         end
       end
     end

--- a/lib/penthouse/tenants/octopus_schema_tenant.rb
+++ b/lib/penthouse/tenants/octopus_schema_tenant.rb
@@ -28,26 +28,26 @@ module Penthouse
       # @see Penthouse::Tenants::SchemaTenant#create
       # @return [void]
       def create(**)
-        switch_shard { super }
+        switch_shard(shard: Octopus.master_shard) { super }
       end
 
       # drops the tenant schema within the master shard
       # @see Penthouse::Tenants::SchemaTenant#delete
       # @return [void]
       def delete(**)
-        switch_shard { super }
+        switch_shard(shard: Octopus.master_shard) { super }
       end
 
       # returns whether or not the schema exists
       # @see Penthouse::Tenants::SchemaTenant#exists?
       # @return [Boolean] whether or not the schema exists in the master shard
       def exists?(**)
-        switch_shard { super }
+        switch_shard(shard: Octopus.master_shard) { super }
       end
 
       private
 
-      def switch_shard(shard: Octopus.master_shard, &block)
+      def switch_shard(shard:, &block)
         Octopus.using(shard) do
           block.call
         end

--- a/lib/penthouse/tenants/octopus_schema_tenant.rb
+++ b/lib/penthouse/tenants/octopus_schema_tenant.rb
@@ -21,30 +21,36 @@ module Penthouse
       # @yield [SchemaTenant] The current tenant instance
       # @return [void]
       def call(shard: Octopus.master_shard, &block)
-        Octopus.using(shard) do
-          super(&block)
-        end
+        switch_shard(shard: shard) { super(&block) }
       end
 
       # creates the tenant schema within the master shard
       # @see Penthouse::Tenants::SchemaTenant#create
       # @return [void]
       def create(**)
-        call { super }
+        switch_shard { super }
       end
 
       # drops the tenant schema within the master shard
       # @see Penthouse::Tenants::SchemaTenant#delete
       # @return [void]
       def delete(**)
-        call { super }
+        switch_shard { super }
       end
 
       # returns whether or not the schema exists
       # @see Penthouse::Tenants::SchemaTenant#exists?
       # @return [Boolean] whether or not the schema exists in the master shard
       def exists?(**)
-        call { super }
+        switch_shard { super }
+      end
+
+      private
+
+      def switch_shard(shard: Octopus.master_shard, &block)
+        Octopus.using(shard) do
+          super(&block)
+        end
       end
     end
   end

--- a/lib/penthouse/tenants/schema_tenant.rb
+++ b/lib/penthouse/tenants/schema_tenant.rb
@@ -42,6 +42,12 @@ module Penthouse
           ActiveRecord::Base.connection.schema_search_path = persistent_schemas.dup.unshift(tenant_schema).join(", ")
           ActiveRecord::Base.connection.clear_query_cache
           block.yield(self)
+        rescue PG::UndefinedTable => ex
+          puts "PG::UndefinedTable Error"
+          puts "Tenant Identifier: #{identifier}"
+          puts "Search Path: #{ActiveRecord::Base.connection.schema_search_path}"
+          puts "Connection Inspect: #{ActiveRecord::Base.connection.inspect}"
+          raise ex
         ensure
           # reset the search path back to the default
           ActiveRecord::Base.connection.schema_search_path = persistent_schemas.dup.unshift(previous_schema).join(", ")

--- a/lib/penthouse/tenants/schema_tenant.rb
+++ b/lib/penthouse/tenants/schema_tenant.rb
@@ -42,12 +42,6 @@ module Penthouse
           ActiveRecord::Base.connection.schema_search_path = persistent_schemas.dup.unshift(tenant_schema).join(", ")
           ActiveRecord::Base.connection.clear_query_cache
           block.yield(self)
-        rescue PG::UndefinedTable => ex
-          puts "PG::UndefinedTable Error"
-          puts "Tenant Identifier: #{identifier}"
-          puts "Search Path: #{ActiveRecord::Base.connection.schema_search_path}"
-          puts "Connection Inspect: #{ActiveRecord::Base.connection.inspect}"
-          raise ex
         ensure
           # reset the search path back to the default
           ActiveRecord::Base.connection.schema_search_path = persistent_schemas.dup.unshift(previous_schema).join(", ")

--- a/lib/penthouse/version.rb
+++ b/lib/penthouse/version.rb
@@ -1,3 +1,3 @@
 module Penthouse
-  VERSION = "0.13.1"
+  VERSION = "0.13.2"
 end


### PR DESCRIPTION
Currently when using the OctopusSchemaTenant and performing a create, destroy or exists?  for a tenant, the gem will switch to that tenant before performing those executions. This doesn't make sense for creating the schema, destroying the schema or checking if the schema exists as these can be done from any schema on the database.

To remove this problem the schema switch has been removed in favour of just doing the switch on the shard.