### PR TITLE
Bugfix: yield tenant

### DIFF
--- a/lib/penthouse/tenants/octopus_schema_tenant.rb
+++ b/lib/penthouse/tenants/octopus_schema_tenant.rb
@@ -49,7 +49,7 @@ module Penthouse
 
       def switch_shard(shard:, &block)
         Octopus.using(shard) do
-          block.call
+          block.yield(self)
         end
       end
     end

--- a/lib/penthouse/tenants/shared_tenant.rb
+++ b/lib/penthouse/tenants/shared_tenant.rb
@@ -28,7 +28,7 @@ module Penthouse
 
       def switch_shard(shard:, &block)
         Octopus.using(shard) do
-          block.call
+          block.yield(self)
         end
       end
     end

--- a/lib/penthouse/version.rb
+++ b/lib/penthouse/version.rb
@@ -1,3 +1,3 @@
 module Penthouse
-  VERSION = "0.14"
+  VERSION = "0.14.1"
 end

--- a/spec/penthouse/tenants/sharded_tenant_spec.rb
+++ b/spec/penthouse/tenants/sharded_tenant_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe Penthouse::Tenants::ShardedTenant do
           expect(ActiveRecord::Base.connection.schema_search_path).to include("public")
         end
       end
+
+      it "should yield the tenant" do
+        subject.call do |tenant|
+          expect(tenant).to be_kind_of(described_class)
+        end
+      end
     end
 
     context "with an invalid shard" do

--- a/spec/penthouse/tenants/shared_tenant_spec.rb
+++ b/spec/penthouse/tenants/shared_tenant_spec.rb
@@ -17,5 +17,11 @@ RSpec.describe Penthouse::Tenants::SharedTenant do
         expect(ActiveRecord::Base.connection.schema_search_path).to include("public")
       end
     end
+
+    it "should yield the tenant" do
+      subject.call do |tenant|
+        expect(tenant).to be_kind_of(described_class)
+      end
+    end
   end
 end


### PR DESCRIPTION
The old tenant types yield themselves into the block when switching, this was missed from the new type and it was also missing from `OctopusSchemaTenant`.